### PR TITLE
Fix. Specify platform for external attributes.

### DIFF
--- a/xlsxwriter/packager.lua
+++ b/xlsxwriter/packager.lua
@@ -72,7 +72,8 @@ function Packager:new(filename)
       istext   = true,
       isfile   = true,
       isdir    = false,
-      exattrib = 0x81800020},
+      exattrib = 0x81800020,
+      platform = 'unix'},
   }
 
   setmetatable(instance, self)


### PR DESCRIPTION
`external attributes` depend from platform.
So this value does not make sense when you crate zip on Windows.
I use KingSoft Office on WinXP and there works both variants, 
but I think this is more correct variant.
